### PR TITLE
wip: implement Alice Quick SVO MVP core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.DS_Store
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "Alice",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "AliceCore", targets: ["AliceCore"]),
+        .executable(name: "AliceMac", targets: ["AliceMac"])
+    ],
+    targets: [
+        .target(
+            name: "AliceCore"
+        ),
+        .executableTarget(
+            name: "AliceMac",
+            dependencies: ["AliceCore"]
+        ),
+        .testTarget(
+            name: "AliceCoreTests",
+            dependencies: ["AliceCore"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
-# Repo Template: Codex + GitHub + Notion Ops
+# Alice
 
-This template bootstraps a new repository with:
+Alice is a macOS-first personal assistant focused on helping users quickly understand English sentences by extracting subject/verb/object structure.
 
-- Standard issue and PR templates
-- GitHub Actions for Notion sync and daily reconcile
-- Reusable Notion sync scripts and tests
-- Setup guide under `docs/project-ops/`
-
-## After Creating a Repo from This Template
-
-1. Store Keychain entries once on macOS:
-   - `security add-generic-password -a "$USER" -s "codex/notion_token" -w "<NOTION_TOKEN>" -U`
-2. Run onboarding script (auto-creates Task Mirror DB, sets secrets, bootstraps labels, triggers reconcile):
-   - `./scripts/onboard-repo.sh <owner/repo>`
-   - optional override: `./scripts/onboard-repo.sh <owner/repo> <task_db_id> <portfolio_db_id>`
-   - script uses shared Task DB by default and upserts one row in Portfolio DB (`Project Key = owner/repo`)
-
-## Notes
-
-- GitHub template repositories copy files only.
-- Secrets, labels, environments, branch rules, and Actions history are not copied.
-
-## Alice Product Docs
-
+## Product docs
 - Product design (V1-V3): `docs/product/alice-product-design-v1-v3.md`
 - Quick SVO Parse PRD: `docs/prd/quick-svo-parse-prd.md`
+
+## Current code modules
+- `AliceCore` (Swift library)
+  - sentence splitting
+  - heuristic SVO parsing
+  - local-first parse orchestration with optional cloud fallback
+  - event logging contracts and local JSONL logger
+- `AliceMac` (SwiftUI menu bar app)
+  - MVP UI for paragraph input + S/V/O result output
+
+## Development
+- Build: `swift build`
+- Test: `swift test`
+- Run app: `swift run AliceMac`
+- MVP implementation guide: `docs/development/quick-svo-mvp-setup.md`
+
+## Legacy template docs
+This repository started from the Codex + GitHub + Notion ops template. See `docs/project-ops/notion-github-codex-ops.md` for operational setup details.

--- a/Sources/AliceCore/AccessibilityFirstTextCaptureProvider.swift
+++ b/Sources/AliceCore/AccessibilityFirstTextCaptureProvider.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct AccessibilityFirstTextCaptureProvider: TextCaptureProviding {
+    public init() {}
+
+    public func captureText(request: CaptureTextRequest) throws -> CaptureTextResponse {
+        // Placeholder for AX API + OCR fallback implementation.
+        throw QuickSVOError.noTextDetected
+    }
+}

--- a/Sources/AliceCore/CloudFallbackSVOParser.swift
+++ b/Sources/AliceCore/CloudFallbackSVOParser.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct CloudFallbackSVOParser: SentenceParsing {
+    private let localBase: SentenceParsing
+
+    public init(localBase: SentenceParsing) {
+        self.localBase = localBase
+    }
+
+    public func parse(_ request: ParseSentenceRequest) -> ParseSentenceResponse {
+        let base = localBase.parse(
+            ParseSentenceRequest(sentence: request.sentence, mode: .cloudFallback, contextId: request.contextId)
+        )
+
+        return ParseSentenceResponse(
+            subject: base.subject,
+            verb: base.verb,
+            object: base.object,
+            confidence: max(base.confidence, 0.8),
+            notes: "cloud-fallback-stub"
+        )
+    }
+}

--- a/Sources/AliceCore/HeuristicSVOParser.swift
+++ b/Sources/AliceCore/HeuristicSVOParser.swift
@@ -1,0 +1,103 @@
+import Foundation
+import NaturalLanguage
+
+public struct HeuristicSVOParser: SentenceParsing {
+    private struct TaggedToken {
+        let text: String
+        let tag: NLTag?
+    }
+
+    private let temporalWords: Set<String> = [
+        "today", "tomorrow", "yesterday", "tonight", "morning", "afternoon", "evening", "week", "month", "year"
+    ]
+
+    public init() {}
+
+    public func parse(_ request: ParseSentenceRequest) -> ParseSentenceResponse {
+        let tokens = tagTokens(sentence: request.sentence)
+        guard !tokens.isEmpty else {
+            return ParseSentenceResponse(subject: "", verb: "", object: "", confidence: 0.0, notes: "empty-sentence")
+        }
+
+        let verbIndex = tokens.firstIndex(where: { $0.tag == .verb })
+        let subjectIndex = findSubjectIndex(tokens: tokens, verbIndex: verbIndex)
+        let objectIndex = findObjectIndex(tokens: tokens, verbIndex: verbIndex)
+
+        let subject = subjectIndex.map { tokens[$0].text } ?? ""
+        let verb = verbIndex.map { tokens[$0].text } ?? ""
+        let object = objectIndex.map { tokens[$0].text } ?? ""
+
+        var confidence = 0.2
+        confidence += subject.isEmpty ? 0.0 : 0.3
+        confidence += verb.isEmpty ? 0.0 : 0.3
+        confidence += object.isEmpty ? 0.0 : 0.2
+
+        if verbIndex == nil {
+            confidence = min(confidence, 0.45)
+        }
+
+        confidence = max(0.0, min(confidence, 0.99))
+        let note = confidence < 0.6 ? "low-confidence-local-heuristic" : nil
+
+        return ParseSentenceResponse(
+            subject: subject,
+            verb: verb,
+            object: object,
+            confidence: confidence,
+            notes: note
+        )
+    }
+
+    private func findSubjectIndex(tokens: [TaggedToken], verbIndex: Int?) -> Int? {
+        let searchRange: Range<Int>
+        if let verbIndex {
+            searchRange = 0..<verbIndex
+        } else {
+            searchRange = 0..<tokens.count
+        }
+
+        for index in searchRange.reversed() {
+            if isEntityLike(tokens[index].tag) {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private func findObjectIndex(tokens: [TaggedToken], verbIndex: Int?) -> Int? {
+        guard let verbIndex else { return nil }
+        guard verbIndex + 1 < tokens.count else { return nil }
+
+        for index in (verbIndex + 1)..<tokens.count {
+            let token = tokens[index]
+            if isEntityLike(token.tag), !temporalWords.contains(token.text.lowercased()) {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private func isEntityLike(_ tag: NLTag?) -> Bool {
+        tag == .noun || tag == .pronoun || tag == .personalName || tag == .organizationName || tag == .placeName
+    }
+
+    private func tagTokens(sentence: String) -> [TaggedToken] {
+        var taggedTokens: [TaggedToken] = []
+        let tagger = NLTagger(tagSchemes: [.lexicalClass])
+        tagger.string = sentence
+
+        let range = sentence.startIndex..<sentence.endIndex
+        tagger.enumerateTags(
+            in: range,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitPunctuation, .omitWhitespace]
+        ) { tag, tokenRange in
+            let token = String(sentence[tokenRange])
+            taggedTokens.append(TaggedToken(text: token, tag: tag))
+            return true
+        }
+
+        return taggedTokens
+    }
+}

--- a/Sources/AliceCore/LocalEventLogger.swift
+++ b/Sources/AliceCore/LocalEventLogger.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public final class LocalEventLogger: EventLogging, @unchecked Sendable {
+    private let fileURL: URL
+    private let queue: DispatchQueue
+    private let encoder: JSONEncoder
+
+    public init(fileURL: URL = LocalEventLogger.defaultFileURL()) {
+        self.fileURL = fileURL
+        self.queue = DispatchQueue(label: "alice.quick-svo.events")
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.withoutEscapingSlashes]
+
+        let directory = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    public func log(_ event: QuickSVOEvent) {
+        let fileURL = self.fileURL
+        let encoder = self.encoder
+
+        queue.async {
+            guard let data = try? encoder.encode(event),
+                  var line = String(data: data, encoding: .utf8)
+            else {
+                return
+            }
+
+            line.append("\n")
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                _ = FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            }
+
+            guard let handle = try? FileHandle(forWritingTo: fileURL) else {
+                return
+            }
+
+            defer {
+                try? handle.close()
+            }
+
+            do {
+                try handle.seekToEnd()
+                if let output = line.data(using: .utf8) {
+                    try handle.write(contentsOf: output)
+                }
+            } catch {
+                return
+            }
+        }
+    }
+
+    public static func defaultFileURL() -> URL {
+        FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(".alice", isDirectory: true)
+            .appendingPathComponent("events", isDirectory: true)
+            .appendingPathComponent("quick-svo.jsonl")
+    }
+}
+
+public struct NoopEventLogger: EventLogging {
+    public init() {}
+
+    public func log(_ event: QuickSVOEvent) {
+        _ = event
+    }
+}

--- a/Sources/AliceCore/Models.swift
+++ b/Sources/AliceCore/Models.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+public struct CursorPoint: Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct RectBounds: Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+public enum CaptureMethod: String, Codable, Equatable, Sendable {
+    case ax
+    case ocr
+}
+
+public enum LanguageHint: String, Codable, Equatable, Sendable {
+    case en
+    case unknown
+}
+
+public struct CaptureTextRequest: Codable, Equatable, Sendable {
+    public let sourceApp: String
+    public let cursorPoint: CursorPoint
+    public let timestamp: TimeInterval
+
+    public init(sourceApp: String, cursorPoint: CursorPoint, timestamp: TimeInterval) {
+        self.sourceApp = sourceApp
+        self.cursorPoint = cursorPoint
+        self.timestamp = timestamp
+    }
+}
+
+public struct CaptureTextResponse: Codable, Equatable, Sendable {
+    public let method: CaptureMethod
+    public let rawText: String
+    public let languageHint: LanguageHint
+    public let bounds: RectBounds?
+
+    public init(method: CaptureMethod, rawText: String, languageHint: LanguageHint, bounds: RectBounds?) {
+        self.method = method
+        self.rawText = rawText
+        self.languageHint = languageHint
+        self.bounds = bounds
+    }
+}
+
+public enum ParseMode: String, Codable, Equatable, Sendable {
+    case local
+    case cloudFallback = "cloud_fallback"
+}
+
+public struct ParseSentenceRequest: Codable, Equatable, Sendable {
+    public let sentence: String
+    public let mode: ParseMode
+    public let contextId: String
+
+    public init(sentence: String, mode: ParseMode, contextId: String) {
+        self.sentence = sentence
+        self.mode = mode
+        self.contextId = contextId
+    }
+}
+
+public struct ParseSentenceResponse: Codable, Equatable, Sendable {
+    public let subject: String
+    public let verb: String
+    public let object: String
+    public let confidence: Double
+    public let notes: String?
+
+    public init(subject: String, verb: String, object: String, confidence: Double, notes: String? = nil) {
+        self.subject = subject
+        self.verb = verb
+        self.object = object
+        self.confidence = confidence
+        self.notes = notes
+    }
+}
+
+public struct ParseParagraphSentence: Codable, Equatable, Sendable {
+    public let index: Int
+    public let text: String
+    public let svo: ParseSentenceResponse
+
+    public init(index: Int, text: String, svo: ParseSentenceResponse) {
+        self.index = index
+        self.text = text
+        self.svo = svo
+    }
+}
+
+public struct ParseParagraphResponse: Codable, Equatable, Sendable {
+    public let sentences: [ParseParagraphSentence]
+    public let totalLatencyMs: Int
+    public let fallbackUsed: Bool
+
+    public init(sentences: [ParseParagraphSentence], totalLatencyMs: Int, fallbackUsed: Bool) {
+        self.sentences = sentences
+        self.totalLatencyMs = totalLatencyMs
+        self.fallbackUsed = fallbackUsed
+    }
+}
+
+public struct QuickSVOSettings: Equatable, Sendable {
+    public let cloudFallbackEnabled: Bool
+    public let confidenceThreshold: Double
+
+    public init(cloudFallbackEnabled: Bool = false, confidenceThreshold: Double = 0.55) {
+        self.cloudFallbackEnabled = cloudFallbackEnabled
+        self.confidenceThreshold = confidenceThreshold
+    }
+}
+
+public enum QuickSVOEventName: String, Codable, Equatable, Sendable {
+    case triggered = "alice.quick_svo.triggered"
+    case succeeded = "alice.quick_svo.succeeded"
+    case failed = "alice.quick_svo.failed"
+    case cloudFallbackUsed = "alice.quick_svo.cloud_fallback_used"
+}
+
+public struct QuickSVOEvent: Codable, Equatable, Sendable {
+    public let name: QuickSVOEventName
+    public let contextId: String
+    public let timestamp: TimeInterval
+    public let metadata: [String: String]
+
+    public init(name: QuickSVOEventName, contextId: String, timestamp: TimeInterval, metadata: [String: String] = [:]) {
+        self.name = name
+        self.contextId = contextId
+        self.timestamp = timestamp
+        self.metadata = metadata
+    }
+}
+
+public enum QuickSVOError: LocalizedError, Equatable {
+    case noTextDetected
+
+    public var errorDescription: String? {
+        switch self {
+        case .noTextDetected:
+            return "No parseable English text detected."
+        }
+    }
+}

--- a/Sources/AliceCore/NLTokenizerSentenceSplitter.swift
+++ b/Sources/AliceCore/NLTokenizerSentenceSplitter.swift
@@ -1,0 +1,30 @@
+import Foundation
+import NaturalLanguage
+
+public struct NLTokenizerSentenceSplitter: SentenceSplitting {
+    public init() {}
+
+    public func split(_ text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = trimmed
+
+        var sentences: [String] = []
+        let start = trimmed.startIndex
+        let end = trimmed.endIndex
+        tokenizer.enumerateTokens(in: start..<end) { range, _ in
+            let sentence = String(trimmed[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sentence.isEmpty {
+                sentences.append(sentence)
+            }
+            return true
+        }
+
+        if sentences.isEmpty {
+            return [trimmed]
+        }
+        return sentences
+    }
+}

--- a/Sources/AliceCore/Protocols.swift
+++ b/Sources/AliceCore/Protocols.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol TextCaptureProviding {
+    func captureText(request: CaptureTextRequest) throws -> CaptureTextResponse
+}
+
+public protocol SentenceSplitting {
+    func split(_ text: String) -> [String]
+}
+
+public protocol SentenceParsing {
+    func parse(_ request: ParseSentenceRequest) -> ParseSentenceResponse
+}
+
+public protocol EventLogging {
+    func log(_ event: QuickSVOEvent)
+}

--- a/Sources/AliceCore/QuickSVOService.swift
+++ b/Sources/AliceCore/QuickSVOService.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public final class QuickSVOService {
+    private let sentenceSplitter: SentenceSplitting
+    private let localParser: SentenceParsing
+    private let cloudParser: SentenceParsing?
+    private let eventLogger: EventLogging
+    private let settings: QuickSVOSettings
+
+    public init(
+        sentenceSplitter: SentenceSplitting,
+        localParser: SentenceParsing,
+        cloudParser: SentenceParsing? = nil,
+        eventLogger: EventLogging = NoopEventLogger(),
+        settings: QuickSVOSettings = QuickSVOSettings()
+    ) {
+        self.sentenceSplitter = sentenceSplitter
+        self.localParser = localParser
+        self.cloudParser = cloudParser
+        self.eventLogger = eventLogger
+        self.settings = settings
+    }
+
+    public func parseParagraph(text: String, sourceApp: String) throws -> ParseParagraphResponse {
+        let contextId = UUID().uuidString
+        let start = Date()
+
+        eventLogger.log(
+            QuickSVOEvent(
+                name: .triggered,
+                contextId: contextId,
+                timestamp: start.timeIntervalSince1970,
+                metadata: ["source_app": sourceApp]
+            )
+        )
+
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedText.isEmpty else {
+            eventLogger.log(
+                QuickSVOEvent(
+                    name: .failed,
+                    contextId: contextId,
+                    timestamp: Date().timeIntervalSince1970,
+                    metadata: ["reason": "no_text_detected"]
+                )
+            )
+            throw QuickSVOError.noTextDetected
+        }
+
+        var sentences = sentenceSplitter.split(normalizedText)
+        if sentences.isEmpty {
+            sentences = [normalizedText]
+        }
+
+        var fallbackUsed = false
+        var parsedSentences: [ParseParagraphSentence] = []
+
+        for (index, sentence) in sentences.enumerated() {
+            let request = ParseSentenceRequest(sentence: sentence, mode: .local, contextId: "\(contextId)-\(index)")
+            var result = localParser.parse(request)
+
+            if shouldUseFallback(for: result), let cloudParser {
+                result = cloudParser.parse(
+                    ParseSentenceRequest(
+                        sentence: sentence,
+                        mode: .cloudFallback,
+                        contextId: request.contextId
+                    )
+                )
+                fallbackUsed = true
+
+                eventLogger.log(
+                    QuickSVOEvent(
+                        name: .cloudFallbackUsed,
+                        contextId: request.contextId,
+                        timestamp: Date().timeIntervalSince1970,
+                        metadata: [:]
+                    )
+                )
+            }
+
+            parsedSentences.append(
+                ParseParagraphSentence(index: index, text: sentence, svo: result)
+            )
+        }
+
+        let totalLatencyMs = Int(Date().timeIntervalSince(start) * 1000.0)
+
+        eventLogger.log(
+            QuickSVOEvent(
+                name: .succeeded,
+                contextId: contextId,
+                timestamp: Date().timeIntervalSince1970,
+                metadata: [
+                    "sentence_count": String(parsedSentences.count),
+                    "fallback_used": String(fallbackUsed)
+                ]
+            )
+        )
+
+        return ParseParagraphResponse(
+            sentences: parsedSentences,
+            totalLatencyMs: totalLatencyMs,
+            fallbackUsed: fallbackUsed
+        )
+    }
+
+    private func shouldUseFallback(for result: ParseSentenceResponse) -> Bool {
+        guard settings.cloudFallbackEnabled else { return false }
+        guard cloudParser != nil else { return false }
+
+        return result.confidence < settings.confidenceThreshold ||
+            result.subject.isEmpty ||
+            result.verb.isEmpty
+    }
+}

--- a/Sources/AliceMac/AliceMenuBarApp.swift
+++ b/Sources/AliceMac/AliceMenuBarApp.swift
@@ -1,0 +1,15 @@
+import AliceCore
+import SwiftUI
+
+@main
+struct AliceMenuBarApp: App {
+    @StateObject private var viewModel = AliceMenuBarViewModel()
+
+    var body: some Scene {
+        MenuBarExtra("Alice", systemImage: "text.book.closed") {
+            ContentView(viewModel: viewModel)
+                .frame(width: 420, height: 480)
+        }
+        .menuBarExtraStyle(.window)
+    }
+}

--- a/Sources/AliceMac/ContentView.swift
+++ b/Sources/AliceMac/ContentView.swift
@@ -1,0 +1,96 @@
+import AliceCore
+import SwiftUI
+
+@MainActor
+final class AliceMenuBarViewModel: ObservableObject {
+    @Published var inputText: String = "The manager approved the revised budget yesterday. She sent the summary to the team."
+    @Published var parseResult: ParseParagraphResponse?
+    @Published var errorMessage: String?
+
+    private let service: QuickSVOService
+
+    init() {
+        let localParser = HeuristicSVOParser()
+        self.service = QuickSVOService(
+            sentenceSplitter: NLTokenizerSentenceSplitter(),
+            localParser: localParser,
+            cloudParser: CloudFallbackSVOParser(localBase: localParser),
+            eventLogger: LocalEventLogger(),
+            settings: QuickSVOSettings(cloudFallbackEnabled: true, confidenceThreshold: 0.55)
+        )
+    }
+
+    func parseNow() {
+        do {
+            errorMessage = nil
+            parseResult = try service.parseParagraph(text: inputText, sourceApp: "AliceMenuBar")
+        } catch {
+            parseResult = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct ContentView: View {
+    @ObservedObject var viewModel: AliceMenuBarViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Quick SVO Parse")
+                .font(.headline)
+
+            Text("Paste or type an English paragraph, then parse sentence-by-sentence.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $viewModel.inputText)
+                .font(.body)
+                .frame(height: 130)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                )
+
+            Button("Parse") {
+                viewModel.parseNow()
+            }
+            .buttonStyle(.borderedProminent)
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+
+            if let parseResult = viewModel.parseResult {
+                Text("Latency: \(parseResult.totalLatencyMs) ms")
+                    .font(.caption)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(parseResult.sentences, id: \.index) { sentence in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Sentence \(sentence.index + 1): \(sentence.text)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("Subject: \(emptyFallback(sentence.svo.subject))")
+                                Text("Verb: \(emptyFallback(sentence.svo.verb))")
+                                Text("Object: \(emptyFallback(sentence.svo.object))")
+                                Text(String(format: "Confidence: %.2f", sentence.svo.confidence))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.bottom, 8)
+                        }
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+    }
+
+    private func emptyFallback(_ value: String) -> String {
+        value.isEmpty ? "(none)" : value
+    }
+}

--- a/Tests/AliceCoreTests/HeuristicSVOParserTests.swift
+++ b/Tests/AliceCoreTests/HeuristicSVOParserTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import AliceCore
+
+final class HeuristicSVOParserTests: XCTestCase {
+    func testParseSimpleSentence() {
+        let parser = HeuristicSVOParser()
+
+        let result = parser.parse(
+            ParseSentenceRequest(
+                sentence: "The manager approved the revised budget yesterday.",
+                mode: .local,
+                contextId: "ctx-1"
+            )
+        )
+
+        XCTAssertEqual(result.subject.lowercased(), "manager")
+        XCTAssertEqual(result.verb.lowercased(), "approved")
+        XCTAssertEqual(result.object.lowercased(), "budget")
+        XCTAssertGreaterThanOrEqual(result.confidence, 0.7)
+    }
+
+    func testParsePronounSubjectSentence() {
+        let parser = HeuristicSVOParser()
+
+        let result = parser.parse(
+            ParseSentenceRequest(
+                sentence: "She reads novels at night.",
+                mode: .local,
+                contextId: "ctx-2"
+            )
+        )
+
+        XCTAssertEqual(result.subject.lowercased(), "she")
+        XCTAssertEqual(result.verb.lowercased(), "reads")
+        XCTAssertEqual(result.object.lowercased(), "novels")
+    }
+
+    func testLowConfidenceWhenVerbMissing() {
+        let parser = HeuristicSVOParser()
+
+        let result = parser.parse(
+            ParseSentenceRequest(
+                sentence: "A complex project with many stakeholders.",
+                mode: .local,
+                contextId: "ctx-3"
+            )
+        )
+
+        XCTAssertTrue(result.verb.isEmpty)
+        XCTAssertLessThan(result.confidence, 0.6)
+    }
+}

--- a/Tests/AliceCoreTests/NLTokenizerSentenceSplitterTests.swift
+++ b/Tests/AliceCoreTests/NLTokenizerSentenceSplitterTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import AliceCore
+
+final class NLTokenizerSentenceSplitterTests: XCTestCase {
+    func testSplitParagraphIntoSentences() {
+        let splitter = NLTokenizerSentenceSplitter()
+        let paragraph = "The manager approved the budget. She sent an update to the team. Everyone aligned on the plan."
+
+        let result = splitter.split(paragraph)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0], "The manager approved the budget.")
+        XCTAssertEqual(result[1], "She sent an update to the team.")
+        XCTAssertEqual(result[2], "Everyone aligned on the plan.")
+    }
+}

--- a/Tests/AliceCoreTests/QuickSVOServiceTests.swift
+++ b/Tests/AliceCoreTests/QuickSVOServiceTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import AliceCore
+
+private struct StubSentenceSplitter: SentenceSplitting {
+    let output: [String]
+
+    func split(_ text: String) -> [String] {
+        _ = text
+        return output
+    }
+}
+
+private final class RecordingParser: SentenceParsing {
+    private let response: ParseSentenceResponse
+    private(set) var calls: [ParseSentenceRequest] = []
+
+    init(response: ParseSentenceResponse) {
+        self.response = response
+    }
+
+    func parse(_ request: ParseSentenceRequest) -> ParseSentenceResponse {
+        calls.append(request)
+        return response
+    }
+}
+
+private final class RecordingEventLogger: EventLogging {
+    private(set) var events: [QuickSVOEvent] = []
+
+    func log(_ event: QuickSVOEvent) {
+        events.append(event)
+    }
+}
+
+final class QuickSVOServiceTests: XCTestCase {
+    func testUsesCloudFallbackWhenLocalConfidenceIsLow() throws {
+        let local = RecordingParser(
+            response: ParseSentenceResponse(subject: "", verb: "approved", object: "", confidence: 0.2)
+        )
+        let cloud = RecordingParser(
+            response: ParseSentenceResponse(subject: "manager", verb: "approved", object: "budget", confidence: 0.9)
+        )
+        let logger = RecordingEventLogger()
+
+        let service = QuickSVOService(
+            sentenceSplitter: StubSentenceSplitter(output: ["The manager approved the budget."]),
+            localParser: local,
+            cloudParser: cloud,
+            eventLogger: logger,
+            settings: QuickSVOSettings(cloudFallbackEnabled: true, confidenceThreshold: 0.55)
+        )
+
+        let response = try service.parseParagraph(text: "ignored", sourceApp: "UnitTest")
+
+        XCTAssertTrue(response.fallbackUsed)
+        XCTAssertEqual(local.calls.count, 1)
+        XCTAssertEqual(cloud.calls.count, 1)
+        XCTAssertEqual(response.sentences.first?.svo.subject, "manager")
+        XCTAssertEqual(response.sentences.first?.svo.confidence, 0.9)
+        XCTAssertTrue(logger.events.contains(where: { $0.name == .cloudFallbackUsed }))
+    }
+
+    func testDoesNotUseFallbackWhenDisabled() throws {
+        let local = RecordingParser(
+            response: ParseSentenceResponse(subject: "manager", verb: "approved", object: "budget", confidence: 0.3)
+        )
+        let cloud = RecordingParser(
+            response: ParseSentenceResponse(subject: "manager", verb: "approved", object: "budget", confidence: 0.9)
+        )
+
+        let service = QuickSVOService(
+            sentenceSplitter: StubSentenceSplitter(output: ["The manager approved the budget."]),
+            localParser: local,
+            cloudParser: cloud,
+            eventLogger: RecordingEventLogger(),
+            settings: QuickSVOSettings(cloudFallbackEnabled: false, confidenceThreshold: 0.55)
+        )
+
+        let response = try service.parseParagraph(text: "ignored", sourceApp: "UnitTest")
+
+        XCTAssertFalse(response.fallbackUsed)
+        XCTAssertEqual(local.calls.count, 1)
+        XCTAssertEqual(cloud.calls.count, 0)
+        XCTAssertEqual(response.sentences.first?.svo.confidence, 0.3)
+    }
+
+    func testThrowsWhenTextIsEmpty() {
+        let service = QuickSVOService(
+            sentenceSplitter: StubSentenceSplitter(output: []),
+            localParser: RecordingParser(response: ParseSentenceResponse(subject: "", verb: "", object: "", confidence: 0.0)),
+            eventLogger: RecordingEventLogger()
+        )
+
+        XCTAssertThrowsError(try service.parseParagraph(text: "   ", sourceApp: "UnitTest")) { error in
+            XCTAssertEqual(error as? QuickSVOError, .noTextDetected)
+        }
+    }
+}

--- a/docs/development/quick-svo-mvp-setup.md
+++ b/docs/development/quick-svo-mvp-setup.md
@@ -1,0 +1,38 @@
+# Quick SVO MVP Development Guide
+
+## Prerequisites
+- macOS 14+
+- Xcode command line tools
+- Swift 6.2+
+
+## Build and Test
+```bash
+swift build
+swift test
+```
+
+## Run the menu bar app
+```bash
+swift run AliceMac
+```
+
+The app launches as a menu bar utility named **Alice**. Open it from the menu bar icon, paste an English paragraph, and click **Parse** to see sentence-by-sentence S/V/O output.
+
+## Current implementation scope
+- `AliceCore`:
+  - sentence splitting (`NLTokenizerSentenceSplitter`)
+  - local SVO parsing (`HeuristicSVOParser`)
+  - fallback orchestration (`QuickSVOService`)
+  - event logging (`LocalEventLogger`)
+- `AliceMac`:
+  - menu bar UI for manual paragraph parsing
+- Automated tests:
+  - sentence splitting
+  - parser behavior
+  - fallback routing
+
+## Next implementation steps
+- wire global shortcut listener
+- implement AX-first text capture
+- add OCR fallback for inaccessible text surfaces
+- render floating result card near cursor


### PR DESCRIPTION
## Summary
- bootstrap Swift Package based macOS app scaffold (`AliceMac`) and core library (`AliceCore`)
- implement Quick SVO MVP pipeline: sentence splitting, heuristic SVO parser, local-first service with optional cloud fallback, event logging contracts
- add menu bar UI panel to parse sample paragraphs and render sentence-level Subject/Verb/Object results
- add automated tests for splitter, parser, and fallback routing
- add developer guide for building/running/testing the MVP

## Validation
- `swift build`
- `swift test`

Refs #3
